### PR TITLE
fix: Adjust epoch time to noon for boleto expiration date calculation

### DIFF
--- a/boleto.go
+++ b/boleto.go
@@ -76,7 +76,14 @@ func (b Boleto) calcExpirationDateAt(now time.Time) (year int, month time.Month,
 		}
 	}
 
-	return epoch.AddDate(0, 0, int(daysSinceEpoch-epochAdjust)).Date()
+	// The date can be the start of a DST period. So, e.g.:
+	//
+	// 1997-08-07T00:00:00 + 6949 days = 2016-10-16T00:00:00.
+	//
+	// But at that date, a DLS period starts. So the go time library go converts
+	// it to 2016-10-15H23:00:00. To avoid that day shift, we add 12 hours to
+	// the final calculated date.
+	return epoch.AddDate(0, 0, int(daysSinceEpoch-epochAdjust)).Add(12 * time.Hour).Date()
 }
 
 // Value extracts and returns the monetary value of the Boleto in cents.

--- a/boleto.go
+++ b/boleto.go
@@ -55,11 +55,11 @@ func (b Boleto) calcExpirationDateAt(now time.Time) (year int, month time.Month,
 	factor, _ := strconv.ParseInt(b.validBarcode[5:9], 10, 32)
 
 	if factor < 1000 {
-		epoch := time.Date(1997, time.August, 7, 0, 0, 0, 0, brTz)
+		epoch := time.Date(1997, time.August, 7, 12, 0, 0, 0, brTz)
 		return epoch.AddDate(0, 0, int(factor)).Date()
 	}
 
-	epoch := time.Date(2000, time.July, 3, 0, 0, 0, 0, brTz)
+	epoch := time.Date(2000, time.July, 3, 12, 0, 0, 0, brTz)
 
 	today := now.In(brTz)
 	daysSinceEpoch := int64(today.Sub(epoch) / (24 * time.Hour))

--- a/boleto_test.go
+++ b/boleto_test.go
@@ -43,6 +43,30 @@ func TestBoleto(t *testing.T) {
 			expectedWritableLine: "70790001182115469120410450517387211900000042148",
 		},
 		{
+			name:                 "Valid Boleto 3",
+			barcode:              "02192100100000368626566857200001797430402100",
+			expectedBank:         "021",
+			expectedCurr:         "9",
+			expectedYear:         2025,
+			expectedMonth:        time.February,
+			expectedDay:          23,
+			expectedValue:        36862,
+			expectedFree:         "6566857200001797430402100",
+			expectedWritableLine: "02196566835720000179074304021004210010000036862",
+		},
+		{
+			name:                 "Valid Boleto 4",
+			barcode:              "02197100000000368626566857200001797430402100",
+			expectedBank:         "021",
+			expectedCurr:         "9",
+			expectedYear:         2025,
+			expectedMonth:        time.February,
+			expectedDay:          22,
+			expectedValue:        36862,
+			expectedFree:         "6566857200001797430402100",
+			expectedWritableLine: "02196566835720000179074304021004710000000036862",
+		},
+		{
 			name:                 "Valid Boleto - DST start",
 			barcode:              "00194694900000010001234567890123456789012345",
 			expectedBank:         "001",
@@ -99,6 +123,29 @@ func TestBoleto(t *testing.T) {
 			year, month, day = b.calcExpirationDateAt(time.Date(2025, time.February, 23, 0, 0, 0, 0, brTz))
 			if year != tt.expectedYear || month != tt.expectedMonth || day != tt.expectedDay {
 				t.Errorf("ExpirationDate() = %v-%v-%v, want %v-%v-%v", year, month, day, tt.expectedYear, tt.expectedMonth, tt.expectedDay)
+			}
+
+			// Today is less then the first 5500 days from the epoch
+			if tt.expectedYear < 2025 ||
+				(tt.expectedYear == 2025 &&
+					(tt.expectedMonth < time.February ||
+						tt.expectedMonth == time.February && tt.expectedDay < 22)) {
+				year, month, day = b.calcExpirationDateAt(time.Date(1999, time.July, 2, 0, 0, 0, 0, brTz))
+				if year != tt.expectedYear || month != tt.expectedMonth || day != tt.expectedDay {
+					t.Errorf("ExpirationDate() = %v-%v-%v, want %v-%v-%v", year, month, day, tt.expectedYear, tt.expectedMonth, tt.expectedDay)
+				}
+
+			}
+
+			// factor 4500 (DST date)
+			if tt.expectedYear < 2025 ||
+				(tt.expectedYear == 2025 &&
+					(tt.expectedMonth < time.February ||
+						tt.expectedMonth == time.February && tt.expectedDay <= 22)) {
+				year, month, day = b.calcExpirationDateAt(time.Date(2012, time.October, 28, 0, 0, 0, 0, brTz))
+				if year != tt.expectedYear || month != tt.expectedMonth || day != tt.expectedDay {
+					t.Errorf("ExpirationDate() = %v-%v-%v, want %v-%v-%v", year, month, day, tt.expectedYear, tt.expectedMonth, tt.expectedDay)
+				}
 			}
 
 			if got := b.Value(); got != tt.expectedValue {

--- a/boleto_test.go
+++ b/boleto_test.go
@@ -43,6 +43,18 @@ func TestBoleto(t *testing.T) {
 			expectedWritableLine: "70790001182115469120410450517387211900000042148",
 		},
 		{
+			name:                 "Valid Boleto - DST start",
+			barcode:              "00194694900000010001234567890123456789012345",
+			expectedBank:         "001",
+			expectedCurr:         "9",
+			expectedYear:         2016,
+			expectedMonth:        time.October,
+			expectedDay:          16,
+			expectedValue:        1000,
+			expectedFree:         "1234567890123456789012345",
+			expectedWritableLine: "00191234546789012345767890123457469490000001000",
+		},
+		{
 			name:                 "Valid Barcode 2 with 1997 date",
 			barcode:              "34196000200000233331098211174108055015849000",
 			expectedBank:         "341",

--- a/parse_test.go
+++ b/parse_test.go
@@ -21,6 +21,16 @@ func TestParseBoleto(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:    "Valid barcode 3",
+			input:   "02192100100000368626566857200001797430402100",
+			wantErr: nil,
+		},
+		{
+			name:    "Valid barcode 4",
+			input:   "02197100000000368626566857200001797430402100",
+			wantErr: nil,
+		},
+		{
 			name:    "Valid barcode with date factor less then 1000",
 			input:   "34196000200000233331098211174108055015849000",
 			wantErr: nil,


### PR DESCRIPTION
That prevents wrong factor calculations when the boleto expiration date is in DST period